### PR TITLE
[Expo Config Plugin] Fixed select identifiers and added system codes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please see [here](setup.md)
 
 ## Also See
 
-### [Demo App] NfcOpenReWriter 
+### [Demo App] NfcOpenReWriter
 
 We have a full featured NFC utility app available for download.
 
@@ -179,8 +179,9 @@ Next, rebuild your app as described in the ["Adding custom native code"](https:/
 
 The plugin provides props for extra customization. Every time you change the props or plugins, you'll need to rebuild (and `prebuild`) the native app. If no extra properties are added, defaults will be used.
 
-- `nfcPermission` (_string | false_): Sets the iOS `NFCReaderUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission. Defaults to `Allow $(PRODUCT_NAME) to interact with nearby NFC devices`.
-- `selectIdentifiers` (_string[]_): Sets the iOS [`com.apple.developer.nfc.readersession.iso7816.select-identifiers`](https://developer.apple.com/documentation/bundleresources/information_property_list/select-identifiers) entitlements to a list of supported application IDs.
+- `nfcPermission` (_string | false_): Sets the iOS `NFCReaderUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission. Defaults to `Allow $(PRODUCT_NAME) to interact with nearby NFC devices` (Info.plist).
+- `selectIdentifiers` (_string[]_): Sets the iOS [`com.apple.developer.nfc.readersession.iso7816.select-identifiers`](https://developer.apple.com/documentation/bundleresources/information_property_list/select-identifiers) to a list of supported application IDs (Info.plist).
+- `systemCodes` (_string[]_): Sets the iOS [`com.apple.developer.nfc.readersession.felica.systemcodes`](https://developer.apple.com/documentation/bundleresources/information_property_list/systemcodes) to a user provided list of FeliCa™ system codes that the app supports (Info.plist). Each system code must be a discrete value. The wild card value (`0xFF`) isn't allowed.
 
 #### Example
 
@@ -192,7 +193,8 @@ The plugin provides props for extra customization. Every time you change the pro
         "react-native-nfc-manager",
         {
           "nfcPermission": "Custom permission message",
-          "selectIdentifiers": ["A0000002471001"]
+          "selectIdentifiers": ["A0000002471001"],
+          "systemCodes": ["8008"]
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0"
+    "@expo/config-plugins": "^3.0.6"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
[Follow up](https://github.com/revtel/react-native-nfc-manager/pull/400#issuecomment-891327197). Fixed select-identifiers being added in the wrong place. Also added support for [system codes](https://developer.apple.com/documentation/bundleresources/information_property_list/systemcodes).

# Test Plan

Added to a project and used prebuild previews to see if code was being added to the correct location (Info.plist instead of entitlements).
