### PR TITLE
fix(android): explicitly set intent FLAG_MUTABLE for android 12+ support

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -1064,7 +1064,12 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
         Activity activity = getCurrentActivity();
         Intent intent = new Intent(activity, activity.getClass());
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        return PendingIntent.getActivity(activity, 0, intent, 0);
+
+        int flag = 0;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+          flag = PendingIntent.FLAG_MUTABLE;
+        }
+        return PendingIntent.getActivity(activity, 0, intent, flag);
     }
 
     private IntentFilter[] getIntentFilters() {


### PR DESCRIPTION
Hi!

We spotted this issue on our project and I managed to track down the right flags for it to work in Android below 12 and above 12.

I used this project to find the flags, so not sure if anything else could be added: https://github.com/metrodroid/metrodroid/blob/00453e7fc3c39dbdb570ad1ff2d5d76d83519393/src/main/java/au/id/micolous/metrodroid/activity/MainActivity.kt#L74

This is the error:
![144873364-e8269a24-de49-47e1-8f1a-baa5565fd839](https://user-images.githubusercontent.com/6363719/144894530-95cc83c6-fd62-4e2b-8ed6-bb1947832492.png)

Error text for search engine visibility:

```
Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
```

