### PR TITLE
update documentation

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -29,9 +29,43 @@ More info on Apple's [doc](https://developer.apple.com/documentation/bundleresou
 
 ## Android
 
-Simple add `uses-permission` into your `AndroidManifest.xml`:
+Update your `AndroidManifest.xml` to contain all of the required permissions and filters
 
-```xml
- <uses-permission android:name="android.permission.NFC" />
 ```
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.lockchainmobi">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.NFC" /> <!--Add this line-->
+    <uses-feature android:name="android.hardware.nfc" android:required="true" /> <!--Add this line to hide your app from NON-NFC devices in the Play Store-->
+
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="false"
+      android:theme="@style/AppTheme">
+      <activity
+        android:name=".MainActivity"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+        android:launchMode="singleTask"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+          <action android:name="android.intent.action.MAIN" />
+          <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+        <intent-filter> <!--Add From Here-->
+          <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+          <category android:name="android.intent.category.DEFAULT"/>
+          <data android:mimeType="text/plain" />
+        </intent-filter>
+        <intent-filter>
+          <action android:name="android.nfc.action.TAG_DISCOVERED" />
+          <category android:name="android.intent.category.DEFAULT" />
+        </intent-filter> <!--Until Here-->
+      </activity>
+    </application>
+</manifest>
+```


### PR DESCRIPTION
Resolves  #415 

As an implementer, the example code wasn't working for me / seemed to have a little bit more of an opinion about the data than was explicitly necessary. I imagine this was because it was lifted out of the example app. The example app has a lot of extra architecture around it. This simple code is self-contained.

Additionally- it appears that a required setup step was missing for Android (perhaps only certain phone models). Prior to this change, the system NDEF record manager would intercept the application's intent.