### PR TITLE
fix(android): Fix for 'new NativeEventEmitter()'  warning which appea…

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -987,6 +987,16 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
         callback.invoke(null, isForegroundEnabled);
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     @Override
     public void onHostResume() {
         Log.d(LOG_TAG, "onResume");


### PR DESCRIPTION
Fix for 'new NativeEventEmitter()'  warning which appears with using RN versions higher than 0.65.0