### PR TITLE
ISO setup.md could be more enlightening. 

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -24,9 +24,7 @@ Additionally, if writing ISO7816 tags add application identifiers (aid) into you
 
 More info on Apple's [doc](https://developer.apple.com/documentation/corenfc/nfciso7816tag)
 
-A incomplete list of aid's can be found here.
-
-https://www.eftlab.com/knowledge-base/211-emv-aid-rid-pix/
+An incomplete list of aid's can be found here. [Application identifier](https://www.eftlab.com/knowledge-base/211-emv-aid-rid-pix/)
 
 3. in Xcode's `Signing & Capabilities` tab, make sure `Near Field Communication Tag Reading` capability had been added, like this:
 

--- a/setup.md
+++ b/setup.md
@@ -13,6 +13,21 @@
 
 More info on Apple's [doc](https://developer.apple.com/documentation/bundleresources/information_property_list/nfcreaderusagedescription?language=objc)
 
+Additionally, if writing ISO7816 tags add application identifiers (aid) into your `info.plist` as needed like this.
+```
+<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+<array>
+  <string>D2760000850100</string>
+  <string>D2760000850101</string>
+</array>
+```
+
+More info on Apple's [doc](https://developer.apple.com/documentation/corenfc/nfciso7816tag)
+
+A incomplete list of aid's can be found here.
+
+https://www.eftlab.com/knowledge-base/211-emv-aid-rid-pix/
+
 3. in Xcode's `Signing & Capabilities` tab, make sure `Near Field Communication Tag Reading` capability had been added, like this:
 
 ![xcode-add-capability](./images/xcode-capability.png "xcode capability")
@@ -34,4 +49,3 @@ Simple add `uses-permission` into your `AndroidManifest.xml`:
 ```xml
  <uses-permission android:name="android.permission.NFC" />
 ```
-


### PR DESCRIPTION
Users not familiar with IOS NFC will not know to add a 
<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>.   I believe this should be added in the setup.md file. 