### PR TITLE
feat(ios): support iso15693 sendRequest

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,10 @@ declare module 'react-native-nfc-manager' {
     transceive: (bytes: number[]) => Promise<number[]>;
   }
 
+  interface NfcVHandler {
+    transceive: (bytes: number[]) => Promise<number[]>;
+  }
+
   interface IsoDepHandler {
     transceive: (bytes: number[]) => Promise<number[]>;
   }
@@ -217,6 +221,7 @@ declare module 'react-native-nfc-manager' {
      */
     ndefHandler: NdefHandler;
     nfcAHandler: NfcAHandler;
+    nfcVHandler: NfcVHandler;
     isoDepHandler: IsoDepHandler;
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,17 @@ declare module 'react-native-nfc-manager' {
     Select = 1 << 4,
     Address = 1 << 5,
     Option = 1 << 6,
+    CommandSpecificBit8 = 1 << 7,
+  }
+
+  export enum Nfc15693ResponseFlagIOS {
+    Error = 1 << 0,
+    ResponseBufferValid = 1 << 1,
+    FinalResponse = 1 << 2,
+    ProtocolExtension = 1 << 3,
+    BlockSecurityStatusBit5 = 1 << 4,
+    BlockSecurityStatusBit6 = 1 << 5,
+    WaitTimeExtension = 1 << 6,
   }
 
   type TNF = 0x0 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07;
@@ -159,6 +170,11 @@ declare module 'react-native-nfc-manager' {
       customCommandCode: number;
       customRequestParameters: number[];
     }) => Promise<number[]>;
+    sendRequest: (params: {
+      flags: number;
+      commandCode: number;
+      data: number[];
+    }) => Promise<[number, number[]]>;
     extendedReadSingleBlock: (params: {
       flags: number;
       blockNumber: number;

--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -1174,6 +1174,39 @@ RCT_EXPORT_METHOD(iso15693_customCommand:(NSDictionary *)options callback:(nonnu
     }
 }
 
+RCT_EXPORT_METHOD(iso15693_sendRequest:(NSDictionary *)options callback:(nonnull RCTResponseSenderBlock)callback)
+{
+    if (@available(iOS 14.0, *)) {
+        if (!tagSession || !tagSession.connectedTag) {
+            callback(@[@"Not connected", [NSNull null]]);
+            return;
+        }
+        
+        id<NFCISO15693Tag> tag = [tagSession.connectedTag asNFCISO15693Tag];
+        if (!tag) {
+            callback(@[@"incorrect tag type", [NSNull null]]);
+            return;
+        }
+        
+        NSInteger flags = [[options objectForKey:@"flags"] integerValue];
+        NSInteger commandCode = [[options objectForKey:@"commandCode"] integerValue];
+        NSData *data = [self arrayToData:[options mutableArrayValueForKey:@"data"]];
+        
+        [tag sendRequestWithFlag:flags
+                     commandCode:commandCode
+                            data:data
+               completionHandler:^(NFCISO15693ResponseFlag responseFlag, NSData *resp, NSError *error) {
+            if (error) {
+                callback(@[getErrorMessage(error), [NSNull null]]);
+                return;
+            }
+            callback(@[[NSNull null], [NSNumber numberWithLong:responseFlag], [NfcManager dataToArray:resp]]);
+        }];
+    } else {
+        callback(@[@"Not support in this device", [NSNull null]]);
+    }
+}
+
 RCT_EXPORT_METHOD(iso15693_extendedReadSingleBlock:(NSDictionary *)options callback:(nonnull RCTResponseSenderBlock)callback)
 {
     if (@available(iOS 13.0, *)) {

--- a/src/NfcManager.js
+++ b/src/NfcManager.js
@@ -7,6 +7,7 @@ import {
 } from './NativeNfcManager';
 import {NdefHandler, NdefStatus} from './NfcTech/NdefHandler';
 import {NfcAHandler} from './NfcTech/NfcAHandler';
+import {NfcVHandler} from './NfcTech/NfcVHandler';
 import {IsoDepHandler} from './NfcTech/IsoDepHandler';
 import {
   handleNativeException,
@@ -122,6 +123,13 @@ class NfcManagerBase {
       this._nfcAHandler = new NfcAHandler();
     }
     return this._nfcAHandler;
+  }
+
+  get nfcVHandler() {
+    if (!this._nfcVHandler) {
+      this._nfcVHandler = new NfcVHandler();
+    }
+    return this._nfcVHandler;
   }
 
   get isoDepHandler() {

--- a/src/NfcManagerIOS.js
+++ b/src/NfcManagerIOS.js
@@ -31,6 +31,8 @@ class NfcManagerIOS extends NfcManagerBase {
     for (const t of tech) {
       if (t === NfcTech.NfcA) {
         techList.push(NfcTech.MifareIOS);
+      } else if (t === NfcTech.NfcV) {
+        techList.push(NfcTech.Iso15693IOS);
       } else {
         techList.push(t);
       }

--- a/src/NfcManagerIOS.js
+++ b/src/NfcManagerIOS.js
@@ -8,6 +8,7 @@ import {
 } from './NfcManager';
 import {
   Nfc15693RequestFlagIOS,
+  Nfc15693ResponseFlagIOS,
   Iso15693HandlerIOS,
 } from './NfcTech/Iso15693HandlerIOS';
 import {handleNativeException} from './NfcError';
@@ -145,4 +146,4 @@ class NfcManagerIOS extends NfcManagerBase {
   }
 }
 
-export {NfcManagerIOS, Nfc15693RequestFlagIOS};
+export {NfcManagerIOS, Nfc15693RequestFlagIOS, Nfc15693ResponseFlagIOS};

--- a/src/NfcTech/Iso15693HandlerIOS.js
+++ b/src/NfcTech/Iso15693HandlerIOS.js
@@ -8,6 +8,17 @@ const Nfc15693RequestFlagIOS = {
   Select: 1 << 4,
   Address: 1 << 5,
   Option: 1 << 6,
+  CommandSpecificBit8: 1 << 7,
+};
+
+const Nfc15693ResponseFlagIOS = {
+  Error: 1 << 0,
+  ResponseBufferValid: 1 << 1,
+  FinalResponse: 1 << 2,
+  ProtocolExtension: 1 << 3,
+  BlockSecurityStatusBit5: 1 << 4,
+  BlockSecurityStatusBit6: 1 << 5,
+  WaitTimeExtension: 1 << 6
 };
 
 class Iso15693HandlerIOS {
@@ -87,6 +98,15 @@ class Iso15693HandlerIOS {
     );
   }
 
+  // https://developer.apple.com/documentation/corenfc/nfciso15693tag/3551933-sendrequestwithflag?language=objc
+  sendRequest({flags, commandCode, data}) {
+    return handleNativeException(
+      callNative('iso15693_sendRequest', [
+        {flags, commandCode, data},
+      ]),
+    );
+  }
+
   extendedReadSingleBlock({flags, blockNumber}) {
     return handleNativeException(
       callNative('iso15693_extendedReadSingleBlock', [{flags, blockNumber}]),
@@ -108,4 +128,4 @@ class Iso15693HandlerIOS {
   }
 }
 
-export {Nfc15693RequestFlagIOS, Iso15693HandlerIOS};
+export {Nfc15693RequestFlagIOS, Nfc15693ResponseFlagIOS, Iso15693HandlerIOS};

--- a/src/NfcTech/NfcVHandler.js
+++ b/src/NfcTech/NfcVHandler.js
@@ -1,0 +1,39 @@
+import {Platform} from 'react-native';
+import {callNative, NativeNfcManager} from '../NativeNfcManager';
+import {handleNativeException} from '../NfcError';
+
+class NfcVHandler {
+  async transceive(bytes) {
+    if (!Array.isArray(bytes)) {
+      throw new Error(
+        'IsoDepHandler.transceive only takes input as a byte array',
+      );
+    }
+
+    if (Platform.OS === 'ios') {
+      const [flags, commandCode, ...data] = bytes;
+      return handleNativeException(
+        new Promise((resolve, reject) => {
+          NativeNfcManager.iso15693_sendRequest(
+            {
+                flags,
+                commandCode,
+                data,
+            },
+            (err, responseFlag, response) => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve([responseFlag, ...response]);
+              }
+            },
+          );
+        }),
+      );
+    }
+
+    return handleNativeException(callNative('transceive', [bytes]));
+  }
+}
+
+export {NfcVHandler};

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import {NfcEvents, NfcTech, NdefStatus} from './NfcManager';
 import {NfcAdapter, NfcManagerAndroid} from './NfcManagerAndroid';
 import {
   Nfc15693RequestFlagIOS,
+  Nfc15693ResponseFlagIOS,
   NfcManagerIOS,
 } from './NfcManagerIOS';
 import * as NfcError from './NfcError';
@@ -26,6 +27,7 @@ export {
   NfcEvents,
   NfcAdapter,
   Nfc15693RequestFlagIOS,
+  Nfc15693ResponseFlagIOS,
   Ndef,
   NdefStatus,
   NfcError,


### PR DESCRIPTION
This PR aims to support [iso15693 sendRequest for ios](https://developer.apple.com/documentation/corenfc/nfciso15693tag/3551933-sendrequestwithflag?language=objc).

`NfcManager.iso15693HandlerIOS.sendRequest` has been added, and the function signature is:

```typescript
sendRequest: (params: {
      flags: number;
      commandCode: number;
      data: number[];
    }) => Promise<[number, number[]]>;
```

The response tuple contains 2 elements:
- the first is `response flag`, see [Apple doc](https://developer.apple.com/documentation/corenfc/nfciso15693responseflag?language=objc)
- the second is `response data`, which is a byte array.

Regarding the first `response flag` value, it's also been exported as an enum in our `index.d.ts`:

```typescript
export enum Nfc15693ResponseFlagIOS {
    Error = 1 << 0,
    ResponseBufferValid = 1 << 1,
    FinalResponse = 1 << 2,
    ProtocolExtension = 1 << 3,
    BlockSecurityStatusBit5 = 1 << 4,
    BlockSecurityStatusBit6 = 1 << 5,
    WaitTimeExtension = 1 << 6,
}
```