### PR TITLE
fix(android): handle enableReaderMode related issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,7 @@ declare module 'react-native-nfc-manager' {
 
   export interface CancelTechReqOpts {
     throwOnError?: boolean = false;
+    delayMsAndroid?: number = 1000;
   }
 
   interface NdefHandler {

--- a/src/NfcManagerAndroid.js
+++ b/src/NfcManagerAndroid.js
@@ -15,6 +15,8 @@ const NfcAdapter = {
   FLAG_READER_NO_PLATFORM_SOUNDS: 0x100,
 };
 
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
 class NfcManagerAndroid extends NfcManagerBase {
   constructor() {
     super();
@@ -42,12 +44,13 @@ class NfcManagerAndroid extends NfcManagerBase {
   };
 
   cancelTechnologyRequest = async (options = {}) => {
-    const {throwOnError = false} = options;
+    const {throwOnError = false, delayMsAndroid = 1000} = options;
 
     try {
       await callNative('cancelTechnologyRequest');
 
-      if (!this.cleanUpTagRegistration) {
+      if (this.cleanUpTagRegistration) {
+        await delay(delayMsAndroid);
         await this.unregisterTagEvent();
         this.cleanUpTagRegistration = false;
       }


### PR DESCRIPTION
The client code can now enable reader mode with `requestTechnology` like this:

```javascript
import NfcManager, {
  NfcTech,
  NfcAdapter,
} from 'react-native-nfc-manager';
...
await NfcManager.requestTechnology([NfcTech.Ndef], {
  isReaderModeEnabled: true,
  readerModeFlags:
    // eslint-disable-next-line no-bitwise
    NfcAdapter.FLAG_READER_NFC_A |
    NfcAdapter.FLAG_READER_NFC_V |
    NfcAdapter.FLAG_READER_NFC_BARCODE |
    NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK |
    NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS,
});
...
```

Also, the issues for previous code are:
- (native) when entering `readerMode` with `requestTechnology`, the `onTagDiscovered` callback doesn't trigger pending `techRequest` to invoke the callback to JavaScript side
- (native) in `unregisterTagEvent`, we should first call `enableDisableForegroundDispatch` then reset flags
- (js) `NfcManagerAndroid` doesn't call `unregisterTagEvent` properly (incorrect logic for `cleanUpTagRegistration` flag)
