### PR TITLE
[ENH] Add increment, decrement, transfer and authenticateKeyB

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -537,6 +537,99 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     }
 
     @ReactMethod
+    public void mifareClassicIncrementBlock(int blockIndex, int value, Callback callback) {
+        synchronized(this) {
+            if (techRequest != null) {
+                try {
+                    MifareClassic mifareTag = (MifareClassic) techRequest.getTechHandle();
+                    if (mifareTag == null || mifareTag.getType() == MifareClassic.TYPE_UNKNOWN) {
+                        // Not a mifare card, fail
+                        callback.invoke("mifareClassicIncrementBlock fail: TYPE_UNKNOWN");
+                        return;
+                    } else if (blockIndex >= mifareTag.getBlockCount()) {
+                        // Check if in range
+                        String msg = String.format("mifareClassicIncrementBlock fail: invalid block %d (max %d)", blockIndex, mifareTag.getBlockCount());
+                        callback.invoke(msg);
+                        return;
+                    }
+
+                    mifareTag.increment(blockIndex, value);
+
+                    callback.invoke(null, true);
+                } catch (TagLostException ex) {
+                    callback.invoke("mifareClassicIncrementBlock fail: TAG_LOST");
+                } catch (Exception ex) {
+                    callback.invoke("mifareClassicIncrementBlock fail: " + ex.toString());
+                }
+            } else {
+                callback.invoke(ERR_NO_TECH_REQ);
+            }
+        }
+    }
+
+    @ReactMethod
+    public void mifareClassicDecrementBlock(int blockIndex, int value, Callback callback) {
+        synchronized(this) {
+            if (techRequest != null) {
+                try {
+                    MifareClassic mifareTag = (MifareClassic) techRequest.getTechHandle();
+                    if (mifareTag == null || mifareTag.getType() == MifareClassic.TYPE_UNKNOWN) {
+                        // Not a mifare card, fail
+                        callback.invoke("mifareClassicDecrementBlock fail: TYPE_UNKNOWN");
+                        return;
+                    } else if (blockIndex >= mifareTag.getBlockCount()) {
+                        // Check if in range
+                        String msg = String.format("mifareClassicDecrementBlock fail: invalid block %d (max %d)", blockIndex, mifareTag.getBlockCount());
+                        callback.invoke(msg);
+                        return;
+                    }
+
+                    mifareTag.decrement(blockIndex, value);
+
+                    callback.invoke(null, true);
+                } catch (TagLostException ex) {
+                    callback.invoke("mifareClassicDecrementBlock fail: TAG_LOST");
+                } catch (Exception ex) {
+                    callback.invoke("mifareClassicDecrementBlock fail: " + ex.toString());
+                }
+            } else {
+                callback.invoke(ERR_NO_TECH_REQ);
+            }
+        }
+    }
+
+    @ReactMethod
+    public void mifareClassicTransferBlock(int blockIndex, Callback callback) {
+        synchronized(this) {
+            if (techRequest != null) {
+                try {
+                    MifareClassic mifareTag = (MifareClassic) techRequest.getTechHandle();
+                    if (mifareTag == null || mifareTag.getType() == MifareClassic.TYPE_UNKNOWN) {
+                        // Not a mifare card, fail
+                        callback.invoke("mifareClassicTransferBlock fail: TYPE_UNKNOWN");
+                        return;
+                    } else if (blockIndex >= mifareTag.getBlockCount()) {
+                        // Check if in range
+                        String msg = String.format("mifareClassicTransferBlock fail: invalid block %d (max %d)", blockIndex, mifareTag.getBlockCount());
+                        callback.invoke(msg);
+                        return;
+                    }
+
+                    mifareTag.transfer(blockIndex);
+
+                    callback.invoke(null, true);
+                } catch (TagLostException ex) {
+                    callback.invoke("mifareClassicTransferBlock fail: TAG_LOST");
+                } catch (Exception ex) {
+                    callback.invoke("mifareClassicTransferBlock fail: " + ex.toString());
+                }
+            } else {
+                callback.invoke(ERR_NO_TECH_REQ);
+            }
+        }
+    }
+
+    @ReactMethod
     public void mifareUltralightReadPages(int pageOffset, Callback callback) {
         synchronized(this) {
             if (techRequest != null) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,8 +122,23 @@ declare module 'react-native-nfc-manager' {
       block: ArrayLike<number>,
       simpliArr: any[],
     ) => Promise<void>;
+    mifareClassicIncrementBlock: (
+      block: ArrayLike<number>,
+      data: number,
+    ) => Promise<void>;
+    mifareClassicDecrementBlock: (
+      block: ArrayLike<number>,
+      data: number,
+    ) => Promise<void>;
+    mifareClassicTransferBlock: (
+      block: ArrayLike<number>,
+    ) => Promise<void>;
     mifareClassicGetSectorCount: () => Promise<number>;
     mifareClassicAuthenticateA: (
+      sector: number,
+      keys: number[],
+    ) => Promise<void>;
+    mifareClassicAuthenticateB: (
       sector: number,
       keys: number[],
     ) => Promise<void>;

--- a/src/NfcTech/MifareClassicHandlerAndroid.js
+++ b/src/NfcTech/MifareClassicHandlerAndroid.js
@@ -67,6 +67,48 @@ class MifareClassicHandlerAndroid {
       callNative('mifareClassicWriteBlock', [block, data]),
     );
   }
+
+  async mifareClassicIncrementBlock(block, value) {
+    if (
+      !value ||
+      Number.isNaN(value)) {
+      throw new Error(
+        `value should be a number`,
+      );
+    }
+
+    return handleNativeException(
+      callNative('mifareClassicIncrementBlock', [block, value]),
+    );
+  }
+
+  async mifareClassicDecrementBlock(block, value) {
+    if (
+      !value ||
+      Number.isNaN(value)) {
+      throw new Error(
+        `value should be a number`,
+      );
+    }
+
+    return handleNativeException(
+      callNative('mifareClassicDecrementBlock', [block, value]),
+    );
+  }
+  async mifareClassicTransferBlock(block) {
+    if (
+      !block ||
+      Number.isNaN(block)) {
+      throw new Error(
+        `block should be a number`,
+      );
+    }
+
+    return handleNativeException(
+      callNative('mifareClassicTransferBlock', [block]),
+    );
+  }
+
 }
 
 export {MifareClassicHandlerAndroid};


### PR DESCRIPTION
There are three methods in the android mifare classic that it's should be a good idea implement it:
- increment
- decrement
- transfer.

This three methods allow you to change the value of a block easily.

The last command that i have add is authenticate with key B, because sometimes you can't write with key A and you need the key B.
I have add that methods copying and paste the writeBlock and change the name of the function and some code inside. I would recommend check it before merge into the main branch, but i can say that is working that methods perfectly, you can check it.

Also it's a good idea make some refactor code of the mifareClassicHandler, because when you call it and after you want to use a method of that class it's something like this:
`await NfcManager.mifareClassicHandlerAndroid.mifareClassicIncrementBlock`
if we are using the class `mifareClassicHandlerAndroid` you don't need to call the method like mifareClassicIncrementBlock, you can say directly: incrementBlock or increment. just in the way like is doing it in Android.

Thanks.