### PR TITLE
XCode 13 build failed fix

### DIFF
--- a/react-native-nfc-manager.podspec
+++ b/react-native-nfc-manager.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m}"
   s.platform = :ios, "8.0"
 
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
## Environment:
React-Native: 0.68.1
react-native-nfc-manager: 3.11.0
expo: 44.0.0
XCode: 13.3.1 (13E500a)

## Package.json:
```json
  "dependencies": {
    "@react-native-community/datetimepicker": "4.0.0",
    "@react-native-community/masked-view": "0.1.11",
    "@react-native-picker/picker": "2.4.1",
    "@react-navigation/bottom-tabs": "^6.3.1",
    "@react-navigation/native": "^6.0.10",
    "@react-navigation/stack": "^6.2.1",
    "axios": "^0.27.2",
    "eas-cli": "^0.52.0",
    "expo": "^44.0.0",
    "expo-barcode-scanner": "~11.2.0",
    "expo-camera": "~12.1.2",
    "expo-image-manipulator": "~10.2.0",
    "expo-location": "~14.0.1",
    "expo-modules-autolinking": "^0.5.5",
    "expo-secure-store": "~11.1.0",
    "expo-splash-screen": "~0.14.1",
    "expo-status-bar": "~1.2.0",
    "expo-updates": "~0.11.7",
    "i18n-js": "^3.8.0",
    "i18next": "^21.6.16",
    "i18next-http-backend": "^1.2.1",
    "moment": "^2.29.1",
    "react": "18.1.0",
    "react-dom": "18.1.0",
    "react-i18next": "^11.8.13",
    "react-native": "0.68.1",
    "react-native-elements": "^3.0.0-alpha.1",
    "react-native-gesture-handler": "~2.4.1",
    "react-native-keyboard-aware-scroll-view": "^0.9.5",
    "react-native-modal": "^13.0.1",
    "react-native-nfc-manager": "3.11.0",
    "react-native-picker-select": "^8.0.2",
    "react-native-reanimated": "~2.8.0",
    "react-native-safe-area-context": "3.3.2",
    "react-native-screens": "~3.13.1",
    "react-native-table-component": "^1.2.1",
    "react-native-web": "0.17.7"
  },
  "devDependencies": {
    "@babel/core": "^7.12.9",
    "babel-jest": "~28.0.2",
    "jest": "^26.6.3",
    "react-native-clean-project": "^4.0.1",
    "react-test-renderer": "~18.1.0"
  }
```

## Description:
Was implementing the NFC feature with iOS 12 / XCode 13, when I tried to build my iOS APP I will encounter ```Undefined symbols for architecture x86_64``` error after a day of investigation found out this error was caused by podspec file dependency name. Changing it from 'React' to 'React-Core' did the trick.
Here's ref: facebook/react-native#29633 (comment)