### PR TITLE
fix: add CoreNFC as a waek framework to avoid crashes on devices without CoreNFC

### DIFF
--- a/react-native-nfc-manager.podspec
+++ b/react-native-nfc-manager.podspec
@@ -15,4 +15,8 @@ Pod::Spec.new do |s|
   s.platform = :ios, "8.0"
 
   s.dependency "React-Core"
+
+  s.xcconfig = {
+    'OTHER_LDFLAGS': '-weak_framework CoreNFC',
+  }
 end


### PR DESCRIPTION
## Description

My app and the demo app (https://developer.apple.com/forums/thread/106057) is crashing on iPhone 6s - iOS 12.5.5 on splash screen while it's loading CoreNFC (see Crash section below).
It's because CoreNFC is available only for iPhone 7 and higher. iPhone 6 has NFC, but it doesn't have CoreNFC (https://stackoverflow.com/questions/25753473/reading-nfc-tags-with-iphone-6-ios-8 ).

The solution is a little bit simple, I just added a flag to weak linking the CoreNFC.
it's based on this answer on stack overflow: https://stackoverflow.com/a/67398931/1489446

 ## Crash
 
```
dyld: Library not loaded: /System/Library/Frameworks/CoreNFC.framework/CoreNFC
  Referenced from: /var/containers/Bundle/Application/FFB5206D-8144-4DD6-815B-864023274C64/MyApp.app/Ton - Dev
  Reason: image not found
(lldb) 
```

## Extra

It probably fixes the issue #326