### PR TITLE
fix(android): avoid native exception while jumping to system NFC settings

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -1034,8 +1034,12 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
             return;
         }
 
-        currentActivity.startActivity(new Intent(Settings.ACTION_NFC_SETTINGS));
-        callback.invoke();
+        try {
+            currentActivity.startActivity(new Intent(Settings.ACTION_NFC_SETTINGS));
+            callback.invoke(null, true);
+        } catch (Exception ex) {
+            callback.invoke(null, false);
+        }
     }
 
     @ReactMethod

--- a/index.d.ts
+++ b/index.d.ts
@@ -271,7 +271,7 @@ declare module 'react-native-nfc-manager' {
     /**
      * Android only
      */
-    goToNfcSetting(): Promise<any>;
+    goToNfcSetting(): Promise<boolean>;
     getLaunchTagEvent(): Promise<TagEvent | null>;
     transceive(bytes: number[]): Promise<number[]>;
     getMaxTransceiveLength(): Promise<number>;


### PR DESCRIPTION
also, returning a boolean value to indicate whether we can find Android system NFC settings