### PR TITLE
Expo config plugin - include ndef entitlement

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -39,13 +39,17 @@ function addValuesToArray(obj, key, values) {
   return obj;
 }
 
-function withIosNfcEntitlement(c) {
+function withIosNfcEntitlement(c, {includeNdefEntitlement}) {
   return withEntitlementsPlist(c, (config) => {
     // Add the required formats
+    let entitlements = ['NDEF', 'TAG']
+    if (includeNdefEntitlement === false) {
+      entitlements.remove('NDEF')
+    }
     config.modResults = addValuesToArray(
       config.modResults,
       'com.apple.developer.nfc.readersession.formats',
-      ['NDEF', 'TAG'],
+      entitlements,
     );
 
     return config;
@@ -81,8 +85,8 @@ function withIosNfcSystemCodes(c, {systemCodes}) {
 }
 
 function withNfc(config, props = {}) {
-  const {nfcPermission, selectIdentifiers, systemCodes} = props;
-  config = withIosNfcEntitlement(config);
+  const {nfcPermission, selectIdentifiers, systemCodes, includeNdefEntitlement} = props;
+  config = withIosNfcEntitlement(config, {includeNdefEntitlement});
   config = withIosNfcSelectIdentifiers(config, {selectIdentifiers});
   config = withIosNfcSystemCodes(config, {systemCodes});
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -44,7 +44,7 @@ function withIosNfcEntitlement(c, {includeNdefEntitlement}) {
     // Add the required formats
     let entitlements = ['NDEF', 'TAG']
     if (includeNdefEntitlement === false) {
-      entitlements.remove('NDEF')
+      entitlements = ['TAG']
     }
     config.modResults = addValuesToArray(
       config.modResults,


### PR DESCRIPTION
Adding option `includeNdefEntitlement` to expo config plugin that when explicitly set to `false`, removes NDEF entitlement. 

Workaround for error 
`Error: Asset validation failed Invalid entitlement for core nfc framework. The sdk version '16.0' and min OS version '13.0' are not compatible for the entitlement 'com.apple.developer.nfc.readersession.formats' because 'NDEF is disallowed`

Error as seen in:
- https://stackoverflow.com/questions/58131299/xcode-testflight-validate-error-itms-90778-ndef-is-disallowed 

Doing so will allow build to be submitted to test flight.

Usage in app.json:
```
    "plugins": [
      [
        "react-native-nfc-manager",
        {
          "includeNdefEntitlement": false
        }
      ],
    ]
```

This is my first PR on open source, any feedback would be very much appreciated :)