### PR TITLE
Update to latest @expo/config-plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.14.2",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "^4.0.16"
+        "@expo/config-plugins": "^6.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",
@@ -1780,19 +1780,18 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-4.0.16.tgz",
-      "integrity": "sha512-UTyE5JTBatMSwoOZCtX0u2H3zkp/ybMftc1228ARMop35Dbq+sYO11Ym3MrY5RPh8PYPofokDSOvoUq1jjORXw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-6.0.1.tgz",
+      "integrity": "sha512-6mqZutxeibXFeqFfoZApFUEH2n1RxGXYMHCdJrDj4eXDBBFZ3aJ0XBoroZcHHHvfRieEsf54vNyJoWp7JZGj8g==",
       "dependencies": {
-        "@expo/config-types": "^43.0.1",
-        "@expo/json-file": "8.2.34",
-        "@expo/plist": "0.0.17",
+        "@expo/config-types": "^48.0.0",
+        "@expo/json-file": "~8.2.37",
+        "@expo/plist": "^0.0.20",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "@react-native/normalize-color": "^2.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.1",
         "find-up": "~5.0.0",
-        "fs-extra": "9.0.0",
         "getenv": "^1.0.0",
         "glob": "7.1.6",
         "resolve-from": "^5.0.0",
@@ -1862,45 +1861,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@expo/config-plugins/node_modules/fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/config-plugins/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@expo/config-plugins/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@expo/config-plugins/node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/locate-path": {
@@ -1970,14 +1936,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@expo/config-plugins/node_modules/universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@expo/config-plugins/node_modules/uuid": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
@@ -1999,17 +1957,17 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "43.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-43.0.1.tgz",
-      "integrity": "sha512-EtllpCGDdB/UdwAIs5YXJwBLpbFQNdlLLrxIvoILA9cXrpQMWkeDCT9lQPJzFRMFcLUaMuGvkzX2tR4tx5EQFQ=="
+      "version": "48.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-48.0.0.tgz",
+      "integrity": "sha512-DwyV4jTy/+cLzXGAo1xftS6mVlSiLIWZjl9DjTCLPFVgNYQxnh7htPilRv4rBhiNs7KaznWqKU70+4zQoKVT9A=="
     },
     "node_modules/@expo/json-file": {
-      "version": "8.2.34",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.34.tgz",
-      "integrity": "sha512-ZxtBodAZGxdLtgKzmsC+8ViUxt1mhFW642Clu2OuG3f6PAyAFsU/SqEGag9wKFaD3x3Wt8VhL+3y5fMJmUFgPw==",
+      "version": "8.2.37",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.37.tgz",
+      "integrity": "sha512-YaH6rVg11JoTS2P6LsW7ybS2CULjf40AbnAHw2F1eDPuheprNjARZMnyHFPkKv7GuxCy+B9GPcbOKgc4cgA80Q==",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "json5": "^1.0.1",
+        "json5": "^2.2.2",
         "write-file-atomic": "^2.3.0"
       }
     },
@@ -2019,17 +1977,6 @@
       "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/@expo/json-file/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
       }
     },
     "node_modules/@expo/json-file/node_modules/write-file-atomic": {
@@ -2043,11 +1990,11 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.17.tgz",
-      "integrity": "sha512-5Ul3d/YOYE6mfum0jCE25XUnkKHZ5vGlU/X2275ZmCtGrpRn1Fl8Nq+jQKSaks3NqTfxdyXROi/TgH8Zxeg2wg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.20.tgz",
+      "integrity": "sha512-UXQ4LXCfTZ580LDHGJ5q62jSTwJFFJ1GqBu8duQMThiHKWbMJ+gajJh6rsB6EJ3aLUr9wcauxneL5LVRFxwBEA==",
       "dependencies": {
-        "@xmldom/xmldom": "~0.7.0",
+        "@xmldom/xmldom": "~0.7.7",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^14.0.0"
       }
@@ -3901,9 +3848,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
-      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.10.tgz",
+      "integrity": "sha512-hb9QhOg5MGmpVkFcoZ9XJMe1em5gd0e2eqqjK87O1dwULedXsnY/Zg/Ju6lcohA+t6jVkmKpe7I1etqhvdRdrQ==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4451,14 +4398,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -11817,13 +11756,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -14052,7 +13987,8 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -20756,19 +20692,18 @@
       }
     },
     "@expo/config-plugins": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-4.0.16.tgz",
-      "integrity": "sha512-UTyE5JTBatMSwoOZCtX0u2H3zkp/ybMftc1228ARMop35Dbq+sYO11Ym3MrY5RPh8PYPofokDSOvoUq1jjORXw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-6.0.1.tgz",
+      "integrity": "sha512-6mqZutxeibXFeqFfoZApFUEH2n1RxGXYMHCdJrDj4eXDBBFZ3aJ0XBoroZcHHHvfRieEsf54vNyJoWp7JZGj8g==",
       "requires": {
-        "@expo/config-types": "^43.0.1",
-        "@expo/json-file": "8.2.34",
-        "@expo/plist": "0.0.17",
+        "@expo/config-types": "^48.0.0",
+        "@expo/json-file": "~8.2.37",
+        "@expo/plist": "^0.0.20",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "@react-native/normalize-color": "^2.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.1",
         "find-up": "~5.0.0",
-        "fs-extra": "9.0.0",
         "getenv": "^1.0.0",
         "glob": "7.1.6",
         "resolve-from": "^5.0.0",
@@ -20817,37 +20752,10 @@
             "path-exists": "^4.0.0"
           }
         },
-        "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-            }
-          }
         },
         "locate-path": {
           "version": "6.0.0",
@@ -20889,11 +20797,6 @@
             "has-flag": "^4.0.0"
           }
         },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
-        },
         "uuid": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
@@ -20911,17 +20814,17 @@
       }
     },
     "@expo/config-types": {
-      "version": "43.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-43.0.1.tgz",
-      "integrity": "sha512-EtllpCGDdB/UdwAIs5YXJwBLpbFQNdlLLrxIvoILA9cXrpQMWkeDCT9lQPJzFRMFcLUaMuGvkzX2tR4tx5EQFQ=="
+      "version": "48.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-48.0.0.tgz",
+      "integrity": "sha512-DwyV4jTy/+cLzXGAo1xftS6mVlSiLIWZjl9DjTCLPFVgNYQxnh7htPilRv4rBhiNs7KaznWqKU70+4zQoKVT9A=="
     },
     "@expo/json-file": {
-      "version": "8.2.34",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.34.tgz",
-      "integrity": "sha512-ZxtBodAZGxdLtgKzmsC+8ViUxt1mhFW642Clu2OuG3f6PAyAFsU/SqEGag9wKFaD3x3Wt8VhL+3y5fMJmUFgPw==",
+      "version": "8.2.37",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.37.tgz",
+      "integrity": "sha512-YaH6rVg11JoTS2P6LsW7ybS2CULjf40AbnAHw2F1eDPuheprNjARZMnyHFPkKv7GuxCy+B9GPcbOKgc4cgA80Q==",
       "requires": {
         "@babel/code-frame": "~7.10.4",
-        "json5": "^1.0.1",
+        "json5": "^2.2.2",
         "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
@@ -20931,14 +20834,6 @@
           "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
           "requires": {
             "@babel/highlight": "^7.10.4"
-          }
-        },
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "requires": {
-            "minimist": "^1.2.0"
           }
         },
         "write-file-atomic": {
@@ -20954,11 +20849,11 @@
       }
     },
     "@expo/plist": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.17.tgz",
-      "integrity": "sha512-5Ul3d/YOYE6mfum0jCE25XUnkKHZ5vGlU/X2275ZmCtGrpRn1Fl8Nq+jQKSaks3NqTfxdyXROi/TgH8Zxeg2wg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.20.tgz",
+      "integrity": "sha512-UXQ4LXCfTZ580LDHGJ5q62jSTwJFFJ1GqBu8duQMThiHKWbMJ+gajJh6rsB6EJ3aLUr9wcauxneL5LVRFxwBEA==",
       "requires": {
-        "@xmldom/xmldom": "~0.7.0",
+        "@xmldom/xmldom": "~0.7.7",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^14.0.0"
       },
@@ -22452,9 +22347,9 @@
       }
     },
     "@xmldom/xmldom": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
-      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA=="
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.10.tgz",
+      "integrity": "sha512-hb9QhOg5MGmpVkFcoZ9XJMe1em5gd0e2eqqjK87O1dwULedXsnY/Zg/Ju6lcohA+t6jVkmKpe7I1etqhvdRdrQ=="
     },
     "abab": {
       "version": "2.0.5",
@@ -22876,11 +22771,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -28538,13 +28428,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -30373,7 +30259,8 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.16"
+    "@expo/config-plugins": "^6.0.1"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
`npx expo-doctor` indicates invalid `@expo/config-plugins@4.1.5`:

```
[stderr] 
Expected package @expo/config-plugins@~6.0.0
[stderr] 
  Found invalid:
[stderr] 
    @expo/config-plugins@4.1.5
[stderr] 
    (for more info, run: npm why @expo/config-plugins)
```
    
Which can be traced back to `react-native-nfc-manager`:
```
@expo/config-plugins@4.1.5
node_modules/react-native-nfc-manager/node_modules/@expo/config-plugins
  @expo/config-plugins@"^4.0.16" from react-native-nfc-manager@3.14.2
  node_modules/react-native-nfc-manager
    react-native-nfc-manager@"^3.14.2" from the root project
 ```
 
Updating to `@expo/config-plugins": "^6.0.1` should mean this no longer appears.

Diffed outputs from `npx expo config --type prebuild` and confirmed that there is no change in output.

If this change is too pedantic/inconsequential to adopt, please close this PR :) 
 