### PR TITLE
Bug: fix intents handling when they don't contain NFC tag [Android]

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -1315,6 +1315,9 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 
         WritableMap parsed = null;
         Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
+        if (tag == null) {
+            return null;
+        }
         // Parcelable[] messages = intent.getParcelableArrayExtra((NfcAdapter.EXTRA_NDEF_MESSAGES));
 
         synchronized(this) {


### PR DESCRIPTION
## Issue description:
`react-native-nfc-manager` [thinks that every new intent is NFC intent](https://github.com/revtel/react-native-nfc-manager/blob/main/android/src/main/java/community/revteltech/nfc/NfcManager.java#L1297)

It leads to issue as `requestTechnology` callback is being called when `tag` is `null` every time when app returns to foreground/quick action is opened.

## What changes have been made?
- added early return if `tag` is `null` in Intent
