### PR TITLE
Bug: restart polling on NFC tag connection error [iOS 16]

### DIFF
--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -195,15 +195,17 @@ continueUserActivity:(NSUserActivity *)userActivity
                 // inherites from NFCNDEFTag, so we simply allow it to connect
                 if ([tagType isEqualToString:requestType] || [requestType isEqualToString:@"Ndef"]) {
                     RCTResponseSenderBlock pendingCallback = techRequestCallback;
-                    techRequestCallback = nil;
 
                     [tagSession connectToTag:tag
                            completionHandler:^(NSError *error) {
                         if (error != nil) {
-                            pendingCallback(@[getErrorMessage(error)]);
+                            NSLog(@"NFCTag restarting polling");
+                            [self->tagSession restartPolling];
                             return;
                         }
                         
+                        self->techRequestCallback = nil;
+
                         pendingCallback(@[[NSNull null], requestType]);
                     }];
                     return;


### PR DESCRIPTION
## Issue description:
After updating to iOS 16 in 50% cases we get error in `requestTechnology` call due to error in connecting to tag.
It is easily reproducible if we move iPhone during NFC scanning.

## What changes have been made?
- changed logic to restart polling instead of raising error during sensor connection

## Result

After applying this patch it works reliably and scans without any issues on iOS 16.
Logs:
```
NFCTag didDetectTags
[CoreNFC] -[NFCTagReaderSession _connectTag:error:]:730 Error Domain=NFCError Code=100 "Tag connection lost" UserInfo={NSLocalizedDescription=Tag connection lost}
NFCTag restarting polling
NFCTag didDetectTags
[CoreNFC] -[NFCTagReaderSession _connectTag:error:]:730 Error Domain=NFCError Code=100 "Tag connection lost" UserInfo={NSLocalizedDescription=Tag connection lost}
NFCTag restarting polling
FCTag didDetectTags
// success
```

After connection error it immediately finds the same tag and connects again.
