### PR TITLE
Config plugins update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.14.2",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "^4.0.16"
+        "@expo/config-plugins": "~7.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",
@@ -1780,26 +1780,25 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-4.0.16.tgz",
-      "integrity": "sha512-UTyE5JTBatMSwoOZCtX0u2H3zkp/ybMftc1228ARMop35Dbq+sYO11Ym3MrY5RPh8PYPofokDSOvoUq1jjORXw==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.2.5.tgz",
+      "integrity": "sha512-w+5ccu1IxBHgyQk9CPFKLZOk8yZQEyTjbJwOzESK1eR7QwosbcsLkN1c1WWUZYiCXwORu3UTwJYll4+X2xxJhQ==",
       "dependencies": {
-        "@expo/config-types": "^43.0.1",
-        "@expo/json-file": "8.2.34",
-        "@expo/plist": "0.0.17",
+        "@expo/config-types": "^49.0.0-alpha.1",
+        "@expo/json-file": "~8.2.37",
+        "@expo/plist": "^0.0.20",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "@react-native/normalize-color": "^2.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.1",
         "find-up": "~5.0.0",
-        "fs-extra": "9.0.0",
         "getenv": "^1.0.0",
         "glob": "7.1.6",
         "resolve-from": "^5.0.0",
-        "semver": "^7.3.5",
+        "semver": "^7.5.3",
         "slash": "^3.0.0",
         "xcode": "^3.0.1",
-        "xml2js": "0.4.23"
+        "xml2js": "0.6.0"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/ansi-styles": {
@@ -1862,45 +1861,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@expo/config-plugins/node_modules/fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/config-plugins/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@expo/config-plugins/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@expo/config-plugins/node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/locate-path": {
@@ -1946,9 +1912,9 @@
       }
     },
     "node_modules/@expo/config-plugins/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1968,14 +1934,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@expo/config-plugins/node_modules/universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/uuid": {
@@ -1999,17 +1957,17 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "43.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-43.0.1.tgz",
-      "integrity": "sha512-EtllpCGDdB/UdwAIs5YXJwBLpbFQNdlLLrxIvoILA9cXrpQMWkeDCT9lQPJzFRMFcLUaMuGvkzX2tR4tx5EQFQ=="
+      "version": "49.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-49.0.0.tgz",
+      "integrity": "sha512-8eyREVi+K2acnMBe/rTIu1dOfyR2+AMnTLHlut+YpMV9OZPdeKV0Bs9BxAewGqBA2slslbQ9N39IS2CuTKpXkA=="
     },
     "node_modules/@expo/json-file": {
-      "version": "8.2.34",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.34.tgz",
-      "integrity": "sha512-ZxtBodAZGxdLtgKzmsC+8ViUxt1mhFW642Clu2OuG3f6PAyAFsU/SqEGag9wKFaD3x3Wt8VhL+3y5fMJmUFgPw==",
+      "version": "8.2.37",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.37.tgz",
+      "integrity": "sha512-YaH6rVg11JoTS2P6LsW7ybS2CULjf40AbnAHw2F1eDPuheprNjARZMnyHFPkKv7GuxCy+B9GPcbOKgc4cgA80Q==",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "json5": "^1.0.1",
+        "json5": "^2.2.2",
         "write-file-atomic": "^2.3.0"
       }
     },
@@ -2019,17 +1977,6 @@
       "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/@expo/json-file/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
       }
     },
     "node_modules/@expo/json-file/node_modules/write-file-atomic": {
@@ -2043,11 +1990,11 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.17.tgz",
-      "integrity": "sha512-5Ul3d/YOYE6mfum0jCE25XUnkKHZ5vGlU/X2275ZmCtGrpRn1Fl8Nq+jQKSaks3NqTfxdyXROi/TgH8Zxeg2wg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.20.tgz",
+      "integrity": "sha512-UXQ4LXCfTZ580LDHGJ5q62jSTwJFFJ1GqBu8duQMThiHKWbMJ+gajJh6rsB6EJ3aLUr9wcauxneL5LVRFxwBEA==",
       "dependencies": {
-        "@xmldom/xmldom": "~0.7.0",
+        "@xmldom/xmldom": "~0.7.7",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^14.0.0"
       }
@@ -3901,9 +3848,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
-      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==",
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.12.tgz",
+      "integrity": "sha512-JpcbUyxzrUShspIZ9uzcIuxTdE+X15sY7dCKGfXrXbQ1CqpMBfqkrNSde2dGqhlC4+EdAF+csoTCiAvYAKVKlA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4451,14 +4398,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -11817,13 +11756,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -14052,7 +13987,8 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -19149,9 +19085,9 @@
       "dev": true
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -20756,26 +20692,25 @@
       }
     },
     "@expo/config-plugins": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-4.0.16.tgz",
-      "integrity": "sha512-UTyE5JTBatMSwoOZCtX0u2H3zkp/ybMftc1228ARMop35Dbq+sYO11Ym3MrY5RPh8PYPofokDSOvoUq1jjORXw==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.2.5.tgz",
+      "integrity": "sha512-w+5ccu1IxBHgyQk9CPFKLZOk8yZQEyTjbJwOzESK1eR7QwosbcsLkN1c1WWUZYiCXwORu3UTwJYll4+X2xxJhQ==",
       "requires": {
-        "@expo/config-types": "^43.0.1",
-        "@expo/json-file": "8.2.34",
-        "@expo/plist": "0.0.17",
+        "@expo/config-types": "^49.0.0-alpha.1",
+        "@expo/json-file": "~8.2.37",
+        "@expo/plist": "^0.0.20",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "@react-native/normalize-color": "^2.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.1",
         "find-up": "~5.0.0",
-        "fs-extra": "9.0.0",
         "getenv": "^1.0.0",
         "glob": "7.1.6",
         "resolve-from": "^5.0.0",
-        "semver": "^7.3.5",
+        "semver": "^7.5.3",
         "slash": "^3.0.0",
         "xcode": "^3.0.1",
-        "xml2js": "0.4.23"
+        "xml2js": "0.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -20817,37 +20752,10 @@
             "path-exists": "^4.0.0"
           }
         },
-        "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-            }
-          }
         },
         "locate-path": {
           "version": "6.0.0",
@@ -20874,9 +20782,9 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -20888,11 +20796,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
         },
         "uuid": {
           "version": "7.0.3",
@@ -20911,17 +20814,17 @@
       }
     },
     "@expo/config-types": {
-      "version": "43.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-43.0.1.tgz",
-      "integrity": "sha512-EtllpCGDdB/UdwAIs5YXJwBLpbFQNdlLLrxIvoILA9cXrpQMWkeDCT9lQPJzFRMFcLUaMuGvkzX2tR4tx5EQFQ=="
+      "version": "49.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-49.0.0.tgz",
+      "integrity": "sha512-8eyREVi+K2acnMBe/rTIu1dOfyR2+AMnTLHlut+YpMV9OZPdeKV0Bs9BxAewGqBA2slslbQ9N39IS2CuTKpXkA=="
     },
     "@expo/json-file": {
-      "version": "8.2.34",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.34.tgz",
-      "integrity": "sha512-ZxtBodAZGxdLtgKzmsC+8ViUxt1mhFW642Clu2OuG3f6PAyAFsU/SqEGag9wKFaD3x3Wt8VhL+3y5fMJmUFgPw==",
+      "version": "8.2.37",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.37.tgz",
+      "integrity": "sha512-YaH6rVg11JoTS2P6LsW7ybS2CULjf40AbnAHw2F1eDPuheprNjARZMnyHFPkKv7GuxCy+B9GPcbOKgc4cgA80Q==",
       "requires": {
         "@babel/code-frame": "~7.10.4",
-        "json5": "^1.0.1",
+        "json5": "^2.2.2",
         "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
@@ -20931,14 +20834,6 @@
           "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
           "requires": {
             "@babel/highlight": "^7.10.4"
-          }
-        },
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "requires": {
-            "minimist": "^1.2.0"
           }
         },
         "write-file-atomic": {
@@ -20954,11 +20849,11 @@
       }
     },
     "@expo/plist": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.17.tgz",
-      "integrity": "sha512-5Ul3d/YOYE6mfum0jCE25XUnkKHZ5vGlU/X2275ZmCtGrpRn1Fl8Nq+jQKSaks3NqTfxdyXROi/TgH8Zxeg2wg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.20.tgz",
+      "integrity": "sha512-UXQ4LXCfTZ580LDHGJ5q62jSTwJFFJ1GqBu8duQMThiHKWbMJ+gajJh6rsB6EJ3aLUr9wcauxneL5LVRFxwBEA==",
       "requires": {
-        "@xmldom/xmldom": "~0.7.0",
+        "@xmldom/xmldom": "~0.7.7",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^14.0.0"
       },
@@ -22452,9 +22347,9 @@
       }
     },
     "@xmldom/xmldom": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
-      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA=="
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.12.tgz",
+      "integrity": "sha512-JpcbUyxzrUShspIZ9uzcIuxTdE+X15sY7dCKGfXrXbQ1CqpMBfqkrNSde2dGqhlC4+EdAF+csoTCiAvYAKVKlA=="
     },
     "abab": {
       "version": "2.0.5",
@@ -22876,11 +22771,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -28538,13 +28428,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -30373,7 +30259,8 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -34341,9 +34228,9 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.14.2",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~7.2.0"
+        "@expo/config-plugins": "~7.2.2"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.16"
+    "@expo/config-plugins": "~7.2.0"
   },
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@expo/config-plugins": "~7.2.0"
+    "@expo/config-plugins": "~7.2.2"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Bump dependency `@expo/config-plugins` to `~7.2.2` in order to support Expo SDK 49.