### PR TITLE
bump @expo/config-plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.14.5",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "^6.0.1"
+        "@expo/config-plugins": "~7.2.2"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",
@@ -1780,11 +1780,11 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-6.0.1.tgz",
-      "integrity": "sha512-6mqZutxeibXFeqFfoZApFUEH2n1RxGXYMHCdJrDj4eXDBBFZ3aJ0XBoroZcHHHvfRieEsf54vNyJoWp7JZGj8g==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.2.5.tgz",
+      "integrity": "sha512-w+5ccu1IxBHgyQk9CPFKLZOk8yZQEyTjbJwOzESK1eR7QwosbcsLkN1c1WWUZYiCXwORu3UTwJYll4+X2xxJhQ==",
       "dependencies": {
-        "@expo/config-types": "^48.0.0",
+        "@expo/config-types": "^49.0.0-alpha.1",
         "@expo/json-file": "~8.2.37",
         "@expo/plist": "^0.0.20",
         "@expo/sdk-runtime-versions": "^1.0.0",
@@ -1795,10 +1795,10 @@
         "getenv": "^1.0.0",
         "glob": "7.1.6",
         "resolve-from": "^5.0.0",
-        "semver": "^7.3.5",
+        "semver": "^7.5.3",
         "slash": "^3.0.0",
         "xcode": "^3.0.1",
-        "xml2js": "0.4.23"
+        "xml2js": "0.6.0"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/ansi-styles": {
@@ -1912,9 +1912,9 @@
       }
     },
     "node_modules/@expo/config-plugins/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1957,9 +1957,9 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "48.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-48.0.0.tgz",
-      "integrity": "sha512-DwyV4jTy/+cLzXGAo1xftS6mVlSiLIWZjl9DjTCLPFVgNYQxnh7htPilRv4rBhiNs7KaznWqKU70+4zQoKVT9A=="
+      "version": "49.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-49.0.0.tgz",
+      "integrity": "sha512-8eyREVi+K2acnMBe/rTIu1dOfyR2+AMnTLHlut+YpMV9OZPdeKV0Bs9BxAewGqBA2slslbQ9N39IS2CuTKpXkA=="
     },
     "node_modules/@expo/json-file": {
       "version": "8.2.37",
@@ -19085,9 +19085,9 @@
       "dev": true
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -20692,11 +20692,11 @@
       }
     },
     "@expo/config-plugins": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-6.0.1.tgz",
-      "integrity": "sha512-6mqZutxeibXFeqFfoZApFUEH2n1RxGXYMHCdJrDj4eXDBBFZ3aJ0XBoroZcHHHvfRieEsf54vNyJoWp7JZGj8g==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.2.5.tgz",
+      "integrity": "sha512-w+5ccu1IxBHgyQk9CPFKLZOk8yZQEyTjbJwOzESK1eR7QwosbcsLkN1c1WWUZYiCXwORu3UTwJYll4+X2xxJhQ==",
       "requires": {
-        "@expo/config-types": "^48.0.0",
+        "@expo/config-types": "^49.0.0-alpha.1",
         "@expo/json-file": "~8.2.37",
         "@expo/plist": "^0.0.20",
         "@expo/sdk-runtime-versions": "^1.0.0",
@@ -20707,10 +20707,10 @@
         "getenv": "^1.0.0",
         "glob": "7.1.6",
         "resolve-from": "^5.0.0",
-        "semver": "^7.3.5",
+        "semver": "^7.5.3",
         "slash": "^3.0.0",
         "xcode": "^3.0.1",
-        "xml2js": "0.4.23"
+        "xml2js": "0.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -20782,9 +20782,9 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -20814,9 +20814,9 @@
       }
     },
     "@expo/config-types": {
-      "version": "48.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-48.0.0.tgz",
-      "integrity": "sha512-DwyV4jTy/+cLzXGAo1xftS6mVlSiLIWZjl9DjTCLPFVgNYQxnh7htPilRv4rBhiNs7KaznWqKU70+4zQoKVT9A=="
+      "version": "49.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-49.0.0.tgz",
+      "integrity": "sha512-8eyREVi+K2acnMBe/rTIu1dOfyR2+AMnTLHlut+YpMV9OZPdeKV0Bs9BxAewGqBA2slslbQ9N39IS2CuTKpXkA=="
     },
     "@expo/json-file": {
       "version": "8.2.37",
@@ -34228,9 +34228,9 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@expo/config-plugins": "^6.0.1"
+    "@expo/config-plugins": "~7.2.2"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Update `@expo/config-plugins` dependency to `~7.2.2` to support Expo SDK 49.

Resolution for `npx expo-doctor` error that specifies version `~7.2.2` is required:

```
Expected package @expo/config-plugins@~7.2.2
Found invalid:
  @expo/config-plugins@6.0.2
  @expo/config-plugins@6.0.2
  @expo/config-plugins@6.0.2
```