### PR TITLE
Reconnect ndef when an ndef is written.

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -241,8 +241,10 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     }
 
     @ReactMethod
-    public void writeNdefMessage(ReadableArray rnArray, Callback callback) {
+    public void writeNdefMessage(ReadableArray rnArray, ReadableMap options, Callback callback) {
         synchronized(this) {
+            boolean reconnectAfterWrite = options.getBoolean("reconnectAfterWrite");
+            
             if (techRequest != null) {
                 try {
                     Ndef ndef = (Ndef)techRequest.getTechHandle();
@@ -251,9 +253,11 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
                     } else {
                         byte[] bytes = rnArrayToBytes(rnArray);
                         ndef.writeNdefMessage(new NdefMessage(bytes));
-                        ndef.close();
-                        //reconnection is needed in order to be able to read the written ndef 
-                        ndef.connect();
+                        if (reconnectAfterWrite) {
+                            ndef.close();
+                            //reconnection is needed in order to be able to read the written ndef 
+                            ndef.connect();
+                        }
                         callback.invoke();
                     }
                 } catch (Exception ex) {

--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -251,6 +251,9 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
                     } else {
                         byte[] bytes = rnArrayToBytes(rnArray);
                         ndef.writeNdefMessage(new NdefMessage(bytes));
+                        ndef.close();
+                        //reconnection is needed in order to be able to read the written ndef 
+                        ndef.connect();
                         callback.invoke();
                     }
                 } catch (Exception ex) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,7 +92,7 @@ declare module 'react-native-nfc-manager' {
   }
 
   interface NdefHandler {
-    writeNdefMessage: (bytes: number[]) => Promise<void>;
+    writeNdefMessage: (bytes: number[] , options?: { reconnectAfterWrite: boolean }) => Promise<void>;
     getNdefMessage: () => Promise<TagEvent | null>;
     makeReadOnly: () => Promise<void>;
     getNdefStatus: () => Promise<{

--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -440,7 +440,7 @@ RCT_EXPORT_METHOD(getNdefMessage: (nonnull RCTResponseSenderBlock)callback)
     }
 }
 
-RCT_EXPORT_METHOD(writeNdefMessage:(NSArray*)bytes callback:(nonnull RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(writeNdefMessage:(NSArray*)bytes options:(NSDictionary *)options callback:(nonnull RCTResponseSenderBlock)callback)
 {
     if (@available(iOS 13.0, *)) {
         id<NFCNDEFTag> ndefTag = nil;

--- a/src/NfcManager.js
+++ b/src/NfcManager.js
@@ -104,8 +104,8 @@ class NfcManagerBase {
 
   setAlertMessage = DoNothing;
 
-  async writeNdefMessage(bytes) {
-    return handleNativeException(callNative('writeNdefMessage', [bytes]));
+  async writeNdefMessage(bytes, options = {}) {
+    return handleNativeException(callNative('writeNdefMessage', [bytes, options]));
   }
 
   async getNdefMessage() {

--- a/src/NfcTech/NdefHandler.js
+++ b/src/NfcTech/NdefHandler.js
@@ -9,8 +9,16 @@ const NdefStatus = {
 };
 
 class NdefHandler {
-  async writeNdefMessage(bytes) {
-    return handleNativeException(callNative('writeNdefMessage', [bytes]));
+  async writeNdefMessage(bytes, options) {
+  
+    const defaultOptions = { reconnectAfterWrite: false };
+    return handleNativeException(
+        callNative('writeNdefMessage', [
+            bytes, 
+            {...defaultOptions, ...options}
+        ])
+    );
+  
   }
 
   async getNdefMessage() {


### PR DESCRIPTION
On android 13, we have this kind of problem : [https://stackoverflow.com/questions/75554547/nfc-getndefmessage-returns-null-after-tag-writing-on-android-13](https://stackoverflow.com/questions/75554547/nfc-getndefmessage-returns-null-after-tag-writing-on-android-13)
This fix is needed in order to be able to read nfc device like [NHS3100](https://www.nxp.com/products/rfid-nfc/nfc-hf/ntag-smartsensor/ntag-smartsensor-with-temperature-sensor-and-digital-ios:NHS3100)