### PR TITLE
fix: cache the tag for later use

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -1293,6 +1293,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
         // Parcelable[] messages = intent.getParcelableArrayExtra((NfcAdapter.EXTRA_NDEF_MESSAGES));
 
         synchronized(this) {
+            this.tag = tag;
             if (writeNdefRequest != null) {
                 writeNdef(
                         tag,


### PR DESCRIPTION
Hello, 

I'd like to enable the workaround for issue #661 
save the tag so the `connect()` function can use it.
In reader mode, the tag is already saved in ivar, add this for the foreground dispatch mode

Thanks,