### PR TITLE
catch security exception on out of date tags

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/Util.java
+++ b/android/src/main/java/community/revteltech/nfc/Util.java
@@ -42,7 +42,9 @@ public class Util {
                     json.put("canMakeReadOnly", ndef.canMakeReadOnly());
                 } catch (NullPointerException e) {
                     json.put("canMakeReadOnly", JSONObject.NULL);
-                }
+                } catch (SecurityException e) {
+                    json.put("canMakeReadOnly", JSONObject.NULL)
+                }   
             } catch (JSONException e) {
                 Log.e(TAG, "Failed to convert ndef into json: " + ndef, e);
             }

--- a/android/src/main/java/community/revteltech/nfc/Util.java
+++ b/android/src/main/java/community/revteltech/nfc/Util.java
@@ -43,6 +43,7 @@ public class Util {
                 } catch (NullPointerException e) {
                     json.put("canMakeReadOnly", JSONObject.NULL);
                 } catch (SecurityException e) {
+                    Log.e(TAG, "Failed due to out of date tag", e);
                     json.put("canMakeReadOnly", JSONObject.NULL)
                 }   
             } catch (JSONException e) {


### PR DESCRIPTION
Not the fix I want but this should stop the app from crashing at least, when the tag becomes out of date. A security exception is thrown when a tag is out of date, this exception was not being caught.

I am looking deeper into this issue, hopefully I find a better solution which shouldn't even raise this exception.