### PR TITLE
bump @expo/config-plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.14.8",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~7.2.2"
+        "@expo/config-plugins": "~7.2.5"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@expo/config-plugins": "~7.2.2"
+    "@expo/config-plugins": "~7.2.5"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Bumps expo/config-plugins from 7.2.2 to 7.2.5 to address a security vulnerability in a dependency in 7.2.2 ref https://github.com/expo/expo/pull/22080