### PR TITLE
fix: missing-radio-disabled-error

### DIFF
--- a/src/NfcError.js
+++ b/src/NfcError.js
@@ -95,6 +95,8 @@ export function buildNfcExceptionIOS(error) {
         return new InvalidParameterLength();
       } else if (code === NfcErrorIOS.errCodes.parameterOutOfBound) {
         return new ParameterOutOfBound();
+      } else if (code === NfcErrorIOS.errCodes.radioDisabled) {
+        return new RadioDisabled();
       } else if (code === NfcErrorIOS.errCodes.tagConnectionLost) {
         return new TagConnectionLost();
       } else if (code === NfcErrorIOS.errCodes.retryExceeded) {


### PR DESCRIPTION
Hello,

Not sure if this is missed by mistake 
it could be raised on iOS 14+, calling `requestTechnology` when the NFC toggle is off in the system settings


Thanks,