### PR TITLE
Implement restartTechnologyRequestIOS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -266,6 +266,7 @@ declare module 'react-native-nfc-manager' {
             le: number;
           },
     ) => Promise<{response: number[]; sw1: number; sw2: number}>;
+    restartTechnologyRequestIOS: () => Promise<NfcTech | null>;
     iso15693HandlerIOS: Iso15693HandlerIOS;
 
     /**

--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -306,6 +306,21 @@ RCT_EXPORT_METHOD(requestTechnology: (NSArray *)techs options: (NSDictionary *)o
     }
 }
 
+RCT_EXPORT_METHOD(restartTechnologyRequest:(nonnull RCTResponseSenderBlock)callback)
+{
+    if (@available(iOS 13.0, *)) {
+        if (tagSession != nil) {
+            NSLog(@"NfcManager restarting polling");
+            [self->tagSession restartPolling];
+            techRequestCallback = callback;
+        } else {
+            callback(@[@"No active registration", [NSNull null]]);
+        }
+    } else {
+        callback(@[@"Not support in this device", [NSNull null]]);
+    }
+}
+
 RCT_EXPORT_METHOD(cancelTechnologyRequest:(nonnull RCTResponseSenderBlock)callback)
 {
     if (@available(iOS 13.0, *)) {

--- a/src/NfcManager.js
+++ b/src/NfcManager.js
@@ -96,6 +96,8 @@ class NfcManagerBase {
 
   requestTechnology = NotImpl;
 
+  restartTechnologyRequestIOS = NotImpl;
+
   cancelTechnologyRequest = NotImpl;
 
   getBackgroundTag = NotImpl;

--- a/src/NfcManagerIOS.js
+++ b/src/NfcManagerIOS.js
@@ -49,6 +49,12 @@ class NfcManagerIOS extends NfcManagerBase {
     );
   };
 
+  restartTechnologyRequestIOS = async () => {
+    return handleNativeException(
+        callNative('restartTechnologyRequest'),
+    );
+  };
+
   cancelTechnologyRequest = async (options = {}) => {
     const {throwOnError = false} = options;
     return handleNativeException(


### PR DESCRIPTION
In some cases we might get disconnected from the NFC tag. When that happens, we are not able to communicate with the NFC tag anymore, so on iOS the only valid further step is to invalidate NFC session with an error, and ask the user to try again. It also seems to be impossible to process multiple NFC tags within a single CoreNFC tag reading session (unless I'm mistaken).

This PR implements additional method called `restartTechnologyRequestIOS` which essentialy wires the `NFCTagReaderSession.restartPolling()` into the react-native-nfc-manager. This API makes it possible to process multiple tags or to retry an NFC operation against the same tag in case of any failure, without actually restarting the NFC scanning prompt.