### PR TITLE
feat: add connect and close methods to NfcManager interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -277,6 +277,8 @@ declare module 'react-native-nfc-manager' {
     transceive(bytes: number[]): Promise<number[]>;
     getMaxTransceiveLength(): Promise<number>;
     setTimeout(timeout: number): Promise<void>;
+    connect: (techs: NfcTech[]) => Promise<void>;
+    close: () => Promise<void>;
     mifareClassicHandlerAndroid: MifareClassicHandlerAndroid;
     mifareUltralightHandlerAndroid: MifareUltralightHandlerAndroid;
     ndefFormatableHandlerAndroid: NdefFormatableHandlerAndroid;


### PR DESCRIPTION
I manually connected to an `NfcV` tag by using the `connect` function of the `NfcManagerAndroid` class. However, I realized that the connect function is not exposed in the `index.d.ts` file. so I added missing methods such as connect and close to the TypeScript declaration file. 