### PR TITLE
feat(NfcManagerIOS): bind native session available methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -252,6 +252,8 @@ declare module 'react-native-nfc-manager' {
     setAlertMessageIOS: (alertMessage: string) => Promise<void>;
     invalidateSessionIOS: () => Promise<void>;
     invalidateSessionWithErrorIOS: (errorMessage: string) => Promise<void>;
+    isSessionAvailableIOS: () => Promise<Boolean>;
+    isTagSessionAvailableIOS: () => Promise<Boolean>;
     sendMifareCommandIOS: (bytes: number[]) => Promise<number[]>;
     sendFelicaCommandIOS: (bytes: number[]) => Promise<number[]>;
     sendCommandAPDUIOS: (

--- a/src/NfcManagerIOS.js
+++ b/src/NfcManagerIOS.js
@@ -91,6 +91,12 @@ class NfcManagerIOS extends NfcManagerBase {
       callNative('invalidateSessionWithError', [errorMessage]),
     );
 
+  isSessionAvailableIOS = async () => 
+    handleNativeException(callNative('isSessionAvailable'));
+  
+  isTagSessionAvailableIOS = async () =>
+    handleNativeException(callNative('isTagSessionAvailable'));
+
   // -------------------------------------
   // (iOS) NfcTech.MifareIOS API
   // -------------------------------------


### PR DESCRIPTION
This PR binds the native `isSessionAvailable` and `isTagSessionAvailable` methods to the JavaScript Module. These methods are only available on iOS and can be helpful to get more information about the current nfc session states.

