### PR TITLE
feat: add iso15693_extendedReadMultipleBlocks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -204,6 +204,11 @@ declare module 'react-native-nfc-manager' {
       flags: number;
       blockNumber: number;
     }) => Promise<number[]>;
+    extendedReadMultipleBlocks: (params: {
+      flags: number;
+      blockNumber: number;
+      blockCount: number;
+    }) => Promise<number[][]>;
     extendedWriteSingleBlock: (params: {
       flags: number;
       blockNumber: number;

--- a/src/NfcTech/Iso15693HandlerIOS.js
+++ b/src/NfcTech/Iso15693HandlerIOS.js
@@ -113,6 +113,14 @@ class Iso15693HandlerIOS {
     );
   }
 
+  extendedReadMultipleBlocks({flags, blockNumber, blockCount}) {
+    return handleNativeException(
+      callNative('iso15693_extendedReadMultipleBlocks', [
+        {flags, blockNumber, blockCount},
+      ]),
+    );
+  }
+
   extendedWriteSingleBlock({flags, blockNumber, dataBlock}) {
     return handleNativeException(
       callNative('iso15693_extendedWriteSingleBlock', [


### PR DESCRIPTION
This PR introduces support for the [extendedReadMultipleBlocks](https://developer.apple.com/documentation/corenfc/nfciso15693tag/3043801-extendedreadmultipleblocks) method for NFCISO15693Tag on iOS.