### PR TITLE
Bump @expo/config-plugins to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-runtime": "^7.12.10",
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-react": "^7.12.10",
-        "@expo/config-plugins": "~9.0.0",
+        "@expo/config-plugins": "~10.0.0",
         "@react-native-community/eslint-config": "^3.2.0",
         "@release-it/conventional-changelog": "^8.0.1",
         "dotenv-cli": "^7.4.2",
@@ -28,7 +28,7 @@
         "typescript": "^4.1.3"
       },
       "peerDependencies": {
-        "@expo/config-plugins": "8 || 9"
+        "@expo/config-plugins": "~10.0.0"
       },
       "peerDependenciesMeta": {
         "@expo/config-plugins": {
@@ -2314,19 +2314,18 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.9.tgz",
-      "integrity": "sha512-pbgbY3SwCMwkijhfe163J05BrTx4MqzeaV+nVgUMs7vRcjHY1tfM57Pdv6SPtgeDvZ8fvdXFXXzkJva+a7C9Bw==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.0.3.tgz",
+      "integrity": "sha512-fjCckkde67pSDf48x7wRuPsgQVIqlDwN7NlOk9/DFgQ1hCH0L5pGqoSmikA1vtAyiA83MOTpkGl3F3wyATyUog==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^52.0.0",
-        "@expo/json-file": "~9.0.0",
-        "@expo/plist": "^0.2.0",
+        "@expo/config-types": "^53.0.4",
+        "@expo/json-file": "~9.1.4",
+        "@expo/plist": "^0.3.4",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
-        "getenv": "^1.0.0",
+        "getenv": "^2.0.0",
         "glob": "^10.4.2",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.4",
@@ -2466,22 +2465,19 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "52.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-52.0.1.tgz",
-      "integrity": "sha512-vD8ZetyKV7U29lR6+NJohYeoLYTH+eNYXJeNiSOrWCz0witJYY11meMmEnpEaVbN89EfC6uauSUOa6wihtbyPQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "53.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-53.0.5.tgz",
+      "integrity": "sha512-kqZ0w44E+HEGBjy+Lpyn0BVL5UANg/tmNixxaRMLS6nf37YsDrLk2VMAmeKMMk5CKG0NmOdVv3ngeUjRQMsy9g==",
+      "dev": true
     },
     "node_modules/@expo/json-file": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.0.0.tgz",
-      "integrity": "sha512-M+55xFVrFzDcgMDf+52lPDLjKB5xwRfStWlv/b/Vu2OLgxGZLWpxoPYjlRoHqxjPbCQIi2ZCbobK+0KuNhsELg==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.1.5.tgz",
+      "integrity": "sha512-prWBhLUlmcQtvN6Y7BpW2k9zXGd3ySa3R6rAguMJkp1z22nunLN64KYTUWfijFlprFoxm9r2VNnGkcbndAlgKA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "json5": "^2.2.3",
-        "write-file-atomic": "^2.3.0"
+        "json5": "^2.2.3"
       }
     },
     "node_modules/@expo/json-file/node_modules/@babel/code-frame": {
@@ -2489,21 +2485,19 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
       "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.2.0.tgz",
-      "integrity": "sha512-F/IZJQaf8OIVnVA6XWUeMPC3OH6MV00Wxf0WC0JhTQht2QgjyHUa3U5Gs3vRtDq8tXNsZneOQRDVwpaOnd4zTQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.3.5.tgz",
+      "integrity": "sha512-9RYVU1iGyCJ7vWfg3e7c/NVyMFs8wbl+dMWZphtFtsqyN9zppGREU3ctlD3i8KUE0sCUTVnLjCWr+VeUIDep2g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "~0.7.7",
+        "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.2.3",
-        "xmlbuilder": "^14.0.0"
+        "xmlbuilder": "^15.1.1"
       }
     },
     "node_modules/@expo/sdk-runtime-versions": {
@@ -5444,12 +5438,10 @@
       "dev": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
-      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -9969,9 +9961,9 @@
       }
     },
     "node_modules/getenv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
-      "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -17037,24 +17029,6 @@
         "node": ">=10.4.0"
       }
     },
-    "node_modules/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/plist/node_modules/xmlbuilder": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
-      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/plugin-error": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
@@ -21451,18 +21425,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
-    "node_modules/write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -21541,11 +21503,10 @@
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
-      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/plugin-transform-runtime": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
+    "@expo/config-plugins": "~10.0.0",
     "@react-native-community/eslint-config": "^3.2.0",
     "@release-it/conventional-changelog": "^8.0.1",
     "dotenv-cli": "^7.4.2",
@@ -59,11 +60,10 @@
     "react": "^16.13.1",
     "react-native": "^0.63.0",
     "release-it": "^17.5.0",
-    "typescript": "^4.1.3",
-    "@expo/config-plugins": "~9.0.0"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "@expo/config-plugins": "8 || 9"
+    "@expo/config-plugins": "9 || 10"
   },
   "peerDependenciesMeta": {
     "@expo/config-plugins": {


### PR DESCRIPTION
Hi team,

I’ve created a PR to bump @expo/config-plugins to v10.

Version 10 of @expo/config-plugins is one of the requirements for Expo v53.

Related: https://github.com/revtel/react-native-nfc-manager/issues/782

Thanks!