### PR TITLE
fix(Android): correct reader mode delay handling

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -1151,9 +1151,9 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
             try {
                 if (isReaderModeEnabled) {
                     if (enable) {
-                        Log.i(LOG_TAG, "enableReaderMode: " + readerModeFlags);
+                        Log.i(LOG_TAG, String.format("enableReaderMode, flags: %d, delay: %d ms", readerModeFlags, readerModeDelay));
                         Bundle readerModeExtras = new Bundle();
-                        readerModeExtras.putInt(NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY, readerModeDelay * 1000);
+                        readerModeExtras.putInt(NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY, readerModeDelay);
                         nfcAdapter.enableReaderMode(currentActivity, new NfcAdapter.ReaderCallback() {
                             @Override
                             public void onTagDiscovered(Tag tag) {

--- a/src/NfcManager.js
+++ b/src/NfcManager.js
@@ -42,7 +42,7 @@ const DEFAULT_REGISTER_TAG_EVENT_OPTIONS = {
   invalidateAfterFirstRead: false,
   isReaderModeEnabled: false,
   readerModeFlags: 0,
-  readerModeDelay: 10,
+  readerModeDelay: 250,
 };
 
 function NotImpl() {


### PR DESCRIPTION
Hello again,

In Android NFC, the constant `EXTRA_READER_PRESENCE_CHECK_DELAY` is an optional extra you can pass when enabling reader mode. It controls how frequently Android checks whether the NFC tag is still present.

The previous implementation set it to 10 seconds which is kinda an invalid input and also only allowed passing seconds while millis can make a difference.

### BREAKING CHANGE

**Defaults:**

If you don’t set it, the JS code passes a default of **250ms now**. (androids system default is around ~125ms but there are some weird nfc chips with an aggressive polling rate from broadcom inside phones, so 250ms seems to be a good start point or default in general)

**readerModeDelay** is now expecting milliseconds!

**When to change it:**

Increase delay (e.g., 500ms–1000ms):

Saves power.
Good to try for longer card communication
Recommended if you don’t need ultra-fast presence detection (e.g., simple card scans).

Decrease delay (e.g., 50ms–200ms):

Faster detection if a card/tag is removed.
Increases CPU/wakelock usage, might reduce battery life.
Only use if your app must detect removal very quickly (e.g., payment terminals or access control).