### PR TITLE
Change peer dependency for @expo/config-plugins to '*'

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "@expo/config-plugins": "9 || 10"
+    "@expo/config-plugins": "*"
   },
   "peerDependenciesMeta": {
     "@expo/config-plugins": {


### PR DESCRIPTION
Changing the @expo/config-plugins dependency to "*", as the current version is 54.0.1 and we are far away with 9 || 10