### PR TITLE
refactor(NfcManager.java): fresh context before each usage, new arch

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -45,7 +45,6 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
     private static final String LOG_TAG = "ReactNativeNfcManager";
     private final List<IntentFilter> intentFilters = new ArrayList<>();
     private final ArrayList<String[]> techLists = new ArrayList<>();
-    private final ReactApplicationContext context;
     private Boolean isForegroundEnabled = false;
     private Boolean isResumed = false;
     private WriteNdefRequest writeNdefRequest = null;
@@ -82,7 +81,6 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
 
     public NfcManager(ReactApplicationContext reactContext) {
         super(reactContext);
-        context = reactContext;
         reactContext.addActivityEventListener(this);
         reactContext.addLifecycleEventListener(this);
         Log.d(LOG_TAG, "NfcManager created");
@@ -1055,6 +1053,7 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
 
     @ReactMethod
     public void start(Callback callback) {
+        var context = getReactApplicationContext();
         NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(context);
         if (nfcAdapter != null) {
             Log.d(LOG_TAG, "start");
@@ -1080,7 +1079,7 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
     @ReactMethod
     public void isSupported(String tech, Callback callback){
         Log.d(LOG_TAG, "isSupported");
-        Activity currentActivity = context.getCurrentActivity();
+        Activity currentActivity = getReactApplicationContext().getCurrentActivity();
         if (currentActivity == null) {
             callback.invoke(ERR_GET_ACTIVITY_FAIL);
             return;
@@ -1107,7 +1106,7 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
     @ReactMethod
     public void isEnabled(Callback callback) {
         Log.d(LOG_TAG, "isEnabled");
-        NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(context);
+        NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getReactApplicationContext());
         if (nfcAdapter != null) {
             callback.invoke(null, nfcAdapter.isEnabled());
         } else {
@@ -1118,7 +1117,7 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
     @ReactMethod
     public void goToNfcSetting(Callback callback) {
         Log.d(LOG_TAG, "goToNfcSetting");
-        Activity currentActivity = context.getCurrentActivity();
+        Activity currentActivity = getReactApplicationContext().getCurrentActivity();
         if (currentActivity == null) {
             callback.invoke(ERR_GET_ACTIVITY_FAIL);
             return;
@@ -1134,7 +1133,7 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
 
     @ReactMethod
     public void getLaunchTagEvent(Callback callback) {
-        Activity currentActivity = context.getCurrentActivity();
+        Activity currentActivity = getReactApplicationContext().getCurrentActivity();
         if (currentActivity == null) {
             callback.invoke(ERR_GET_ACTIVITY_FAIL);
             return;
@@ -1349,6 +1348,7 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
 
     private void enableDisableForegroundDispatch(boolean enable) {
         Log.i(LOG_TAG, "enableForegroundDispatch, enable = " + enable);
+        var context = getReactApplicationContext();
         NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(context);
         Activity currentActivity = context.getCurrentActivity();
         final NfcManager manager = this;
@@ -1407,7 +1407,7 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
     }
 
     private PendingIntent getPendingIntent() {
-        Activity activity = context.getCurrentActivity();
+        Activity activity = getReactApplicationContext().getCurrentActivity();
         assert activity != null;
         Intent intent = new Intent(activity, activity.getClass());
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
@@ -1440,7 +1440,7 @@ class NfcManager extends NativeNfcManagerSpec implements ActivityEventListener, 
             Log.d(LOG_TAG, "onReceive " + intent);
             final String action = intent.getAction();
 
-            if (action.equals(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)) {
+            if (action != null && action.equals(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)) {
                 final int state = intent.getIntExtra(NfcAdapter.EXTRA_ADAPTER_STATE,
                         NfcAdapter.STATE_OFF);
                 String stateStr = "unknown";


### PR DESCRIPTION
RN core team recommends fetching the activity by getting the context from the parent class on each usage again

This is why we should drop the cached class member for the context as we can retrieve it from the baseclass through `getReactApplicationContext()` and therefore `getReactApplicationContext().getCurrentActivity()` freshly on each usage

This will add proper context and activity support by following the new recommendations by RN.

see: https://github.com/facebook/react-native/commit/1408c69fd8c5327bd3390fce8ed41e20299a5bfa

