### PR TITLE
fix(NfcManager.java): context and activity handling, old arch (RN 0.80 & RN 0.81 support)

### DIFF
--- a/android/src/main/java/community/revteltech/nfc/NfcManager.java
+++ b/android/src/main/java/community/revteltech/nfc/NfcManager.java
@@ -45,7 +45,6 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     private static final String LOG_TAG = "ReactNativeNfcManager";
     private final List<IntentFilter> intentFilters = new ArrayList<>();
     private final ArrayList<String[]> techLists = new ArrayList<>();
-    private final Context context;
     private Boolean isForegroundEnabled = false;
     private Boolean isResumed = false;
     private WriteNdefRequest writeNdefRequest = null;
@@ -82,7 +81,6 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 
     public NfcManager(ReactApplicationContext reactContext) {
         super(reactContext);
-        context = reactContext;
         reactContext.addActivityEventListener(this);
         reactContext.addLifecycleEventListener(this);
         Log.d(LOG_TAG, "NfcManager created");
@@ -1010,12 +1008,13 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 
     @ReactMethod
     public void start(Callback callback) {
+        var context = getReactApplicationContext();
         NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(context);
         if (nfcAdapter != null) {
             Log.d(LOG_TAG, "start");
 
             IntentFilter filter = new IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED);
-            Activity currentActivity = getCurrentActivity();
+            Activity currentActivity = context.getCurrentActivity();
             if (currentActivity == null) {
                 callback.invoke(ERR_GET_ACTIVITY_FAIL);
                 return;
@@ -1035,7 +1034,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     @ReactMethod
     public void isSupported(String tech, Callback callback){
         Log.d(LOG_TAG, "isSupported");
-        Activity currentActivity = getCurrentActivity();
+        Activity currentActivity = getReactApplicationContext().getCurrentActivity();
         if (currentActivity == null) {
             callback.invoke(ERR_GET_ACTIVITY_FAIL);
             return;
@@ -1062,7 +1061,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     @ReactMethod
     public void isEnabled(Callback callback) {
         Log.d(LOG_TAG, "isEnabled");
-        NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(context);
+        NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getReactApplicationContext());
         if (nfcAdapter != null) {
             callback.invoke(null, nfcAdapter.isEnabled());
         } else {
@@ -1073,7 +1072,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     @ReactMethod
     public void goToNfcSetting(Callback callback) {
         Log.d(LOG_TAG, "goToNfcSetting");
-        Activity currentActivity = getCurrentActivity();
+        Activity currentActivity = getReactApplicationContext().getCurrentActivity();
         if (currentActivity == null) {
             callback.invoke(ERR_GET_ACTIVITY_FAIL);
             return;
@@ -1089,7 +1088,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 
     @ReactMethod
     public void getLaunchTagEvent(Callback callback) {
-        Activity currentActivity = getCurrentActivity();
+        Activity currentActivity = getReactApplicationContext().getCurrentActivity();
         if (currentActivity == null) {
             callback.invoke(ERR_GET_ACTIVITY_FAIL);
             return;
@@ -1197,8 +1196,9 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
 
     private void enableDisableForegroundDispatch(boolean enable) {
         Log.i(LOG_TAG, "enableForegroundDispatch, enable = " + enable);
+        var context = getReactApplicationContext();
         NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(context);
-        Activity currentActivity = getCurrentActivity();
+        Activity currentActivity = context.getCurrentActivity();
         final NfcManager manager = this;
         if (nfcAdapter != null && currentActivity != null && !currentActivity.isFinishing()) {
             try {
@@ -1255,7 +1255,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
     }
 
     private PendingIntent getPendingIntent() {
-        Activity activity = getCurrentActivity();
+        Activity activity = getReactApplicationContext().getCurrentActivity();
         assert activity != null;
         Intent intent = new Intent(activity, activity.getClass());
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
@@ -1288,7 +1288,7 @@ class NfcManager extends ReactContextBaseJavaModule implements ActivityEventList
             Log.d(LOG_TAG, "onReceive " + intent);
             final String action = intent.getAction();
 
-            if (action.equals(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)) {
+            if (action != null && action.equals(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)) {
                 final int state = intent.getIntExtra(NfcAdapter.EXTRA_ADAPTER_STATE,
                         NfcAdapter.STATE_OFF);
                 String stateStr = "unknown";


### PR DESCRIPTION
getCurrentActivity of `ReactContextBaseJavaModule` was deprecated in rn 0.80.1 and removed in >=0.81, see: https://github.com/facebook/react-native/blob/main/CHANGELOG.md#android-specific-21

context and currentActivity needs to get fetched on each usage through BaseJavaModule (parent class) see: https://github.com/facebook/react-native/commit/1408c69fd8c5327bd3390fce8ed41e20299a5bfa

this will fix the behaviour on old arch and resolves wrong isSupported isEnabled state etc.