### PR TITLE
fix(ios): return after the "No session available" callback in getTag

### DIFF
--- a/ios/NfcManager.m
+++ b/ios/NfcManager.m
@@ -415,6 +415,7 @@ RCT_EXPORT_METHOD(getTag: (nonnull RCTResponseSenderBlock)callback)
             }
         } else {
             callback(@[@"No session available", [NSNull null]]);
+            return;
         }
         
         if (ndefTag) {


### PR DESCRIPTION
Fixes #833.

### The bug

`getTag()` handles the no-session case by invoking the callback with an error, but does not return. Execution continues past the `if (tagSession != nil)` block to the shared success callback at the end:

```objc
if (tagSession != nil) {
    ...
} else {
    callback(@[@"No session available", [NSNull null]]);
    // no return
}

if (ndefTag) { ... return; }

callback(@[[NSNull null], rnTag]);   // <- runs for the no-session case too
```

`ndefTag` is still `nil` on that path, so the second `callback(...)` always runs. One `getTag()` call invokes its callback twice.

### Why it matters now

On the old architecture the extra invocation was silently dropped. Under the New Architecture's TurboModule interop the callback is wrapped in a one-shot guard, and the second call trips a glog `CHECK`:

```
callback arg cannot be called more than once
```

which aborts the process (SIGABRT), rather than throwing something catchable in JS.

It is easy to reach: `getTag()` right after a scan is cancelled, or after the session has already closed, takes the no-session branch every time.

### The fix

One line. `return` after the error callback, matching how the other early-exit paths in this method already behave.

I have been running this patched into `3.17.2` in production for several weeks and it removes the crash. The same missing `return` is present on the v4 branch in `ios/NfcManager.mm`, if you would like me to open a matching PR there.